### PR TITLE
Major Vulnerability Fix

### DIFF
--- a/mods/deathmatch/resources/account/s_characters.lua
+++ b/mods/deathmatch/resources/account/s_characters.lua
@@ -533,6 +533,7 @@ function Characters_onCharacterChange()
 
     setElementDataEx(client, "loggedin", 0, true)
     setElementDataEx(client, "dbid", 0, true)
+    setElementDataEx(client, "money", 0)
     setElementDataEx(client, "bankmoney", 0)
     setElementDataEx(client, "account:character:id", false)
     setElementAlpha(client, 0)


### PR DESCRIPTION
This vulnerability has existed since OWL 1.0, which enables an attacker to still use cash when changing characters which i discovered after testing my own server and was able to still buy things without money being deducted from my character which potentially could double my money.